### PR TITLE
added timeout for AuthServiceProxy

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ def openRpc(cfg, walletName):
     if walletName != None:
         url += "wallet/%s" % walletName
 
-    return AuthServiceProxy(url)
+    return AuthServiceProxy(url, timeout=240)
 
 # testRpc exits if RPC fails
 def testRpc(rpc, name):


### PR DESCRIPTION
should fix https://github.com/DeFiCh/defi-btc-anchorer/issues/3.
If someone can outsource this to the `config.toml` would be great , but a quick fix. 